### PR TITLE
change tl legacy name, add leaderos form, recommend non premium client mod

### DIFF
--- a/guides/account.md
+++ b/guides/account.md
@@ -49,6 +49,8 @@ Nếu bạn không nhớ mật khẩu của mình, hãy xem phần [Khôi phục
 
 ## Khôi phục tài khoản :id=recover
 
+?> Bạn có thể khôi phục tài khoản (đặt lại mật khẩu) bằng cách [điền vào biểu mẫu online tại đây](https://3fmc.com/login).
+
 Để bắt đầu khôi phục tài khoản, hãy vào 3FMC và dùng lệnh `/email recover <địa chỉ email>`  
 Bạn cần phải thêm địa chỉ email từ trước để có thế khôi phục tài khoản.
 

--- a/guides/join.md
+++ b/guides/join.md
@@ -11,6 +11,7 @@
 - Một số launcher khác có thể cân nhắc thêm
   - [Lunar Client (premium)](https://www.lunarclient.com/)
   - [Salwyrr (premium)](https://www.salwyrr.com/)
+  - [AxolotlClient (không yêu cầu premium)](https://modrinth.com/mod/axolotlclient) (hơi khó cài, đòi hỏi trình độ cao)
   - ??? Client (soon:tm:)
 
 !> Không khuyến khích dùng **TLauncher** do gây ra lỗi với hệ thống skin và những nghi vấn theo dõi người dùng. Tìm hiểu thêm [tại đây](https://www.reddit.com/r/PiratedGames/comments/nay62e/which_are_the_best_minecraft_cracked_launchers/gxy9rr5/)

--- a/guides/join.md
+++ b/guides/join.md
@@ -7,7 +7,7 @@
 - Nếu bạn đã có tài khoản premium thì có thể tải game trên trang chính thức của Mojang: https://www.minecraft.net/en-us/download
 - Nếu bạn không có tài khoản premium (hoặc không biết là gì) thì hãy tải Launcher khác
   - Bạn có thể tìm hiểu trên Google
-  - Khuyến khích dùng [**TL Legacy**](https://tlaun.ch/) (tải trực tiếp [tại đây](https://tlaun.ch/installer))
+  - Khuyến khích dùng [**Legacy Launcher**](https://tlaun.ch/) (tải trực tiếp [tại đây](https://tlaun.ch/installer))
 - Một số launcher khác có thể cân nhắc thêm
   - [Lunar Client (premium)](https://www.lunarclient.com/)
   - [Salwyrr (premium)](https://www.salwyrr.com/)


### PR DESCRIPTION
- TL Legacy changed their name to Legacy Launcher
  - I tried my best to include step-by-step web forms instructions alongside ingame instructions but it looks messy and distracting af. Hopefully a small notice will be enough.
- Add LeaderOS form link for members who have reading difficulties.
- After months of using, I personally recommend Axolotl Client now.